### PR TITLE
Fix two issues with scope

### DIFF
--- a/src/eval/env.rs
+++ b/src/eval/env.rs
@@ -11,13 +11,17 @@ use {
 /// Eval a list of Stmts and return the last's Value.
 pub fn eval(src: &str) -> Result<Value> {
     let mut env = Env::new();
-    env.eval_src(src)
+    let val = env.eval_src(src);
+    debug_assert_eq!(env.scopes.len(), 1);
+    val
 }
 
 /// Render source to a String.
 pub fn render(source: &str) -> Result<String> {
     let mut env = Env::new();
-    env.render(source)
+    let string = env.render(source);
+    debug_assert_eq!(env.scopes.len(), 1);
+    string
 }
 
 /// Error-ish that lets us abort what we're doing.
@@ -314,7 +318,10 @@ impl Env {
                         Err(e) => match e.kind {
                             ErrorKind::Jump(Jump::Break) => break,
                             ErrorKind::Jump(Jump::Continue) => continue,
-                            _ => return Err(e),
+                            _ => {
+                                self.pop_scope();
+                                return Err(e)
+                            },
                         },
                     }
                     self.scope().borrow_mut().clear();
@@ -485,7 +492,10 @@ impl Env {
                 Err(e) => match e.kind {
                     ErrorKind::Jump(Jump::Break) => break,
                     ErrorKind::Jump(Jump::Continue) => continue,
-                    _ => return Err(e),
+                    _ => {
+                        self.pop_scope();
+                        return Err(e)
+                    },
                 },
             }
             self.scope().borrow_mut().clear();

--- a/src/eval/env.rs
+++ b/src/eval/env.rs
@@ -276,6 +276,7 @@ impl Env {
                             }
                             let out = self.block(&body);
                             self.pop_scope();
+                            self.pop_scope();
                             match out {
                                 Ok(v) => v,
                                 Err(e) => match e.kind {
@@ -294,7 +295,10 @@ impl Env {
                 for (test, body) in conds {
                     if self.eval(test)?.to_bool() {
                         self.push_scope();
-                        self.block(body)?;
+                        self.block(body).map_err(|e| {
+                            self.pop_scope();
+                            e
+                        })?;
                         self.pop_scope();
                         break;
                     }

--- a/tests/eval_test.rs
+++ b/tests/eval_test.rs
@@ -264,6 +264,30 @@ test()
 "#,
         "BYE"
     );
+
+    assert_render!(
+        r#"
+def test()
+    for i in [1,2,3]
+        print("BYE")
+        return
+    print("OK!")
+test()
+"#,
+        "BYE"
+    );
+
+    assert_render!(
+        r#"
+def test()
+    while true
+        print("BYE")
+        return
+    print("OK!")
+test()
+"#,
+        "BYE"
+    );
 }
 
 // #[test]


### PR DESCRIPTION
1. When `Stmt:Call` is evaluated, two scopes are pushed, but only one is
popped. This manifested as a `can't find var` [issue in deadwiki][1]
when the "leaked" scope is cleared by `Eval::eval_for`.

2. When `Stmt::If`, `Stmt::For`, or `Stmt::While` are evaluated, a scope is
pushed but not popped when the block contains a return statement. Adding a
debug assertion makes it easier to test for.

[1]: https://github.com/xvxx/deadwiki/issues/14